### PR TITLE
remove spec requires supportconfig-plugin-tag (bsc#1235145)

### DIFF
--- a/packaging/suse/trento-supportconfig-plugin/trento-supportconfig-plugin.spec
+++ b/packaging/suse/trento-supportconfig-plugin/trento-supportconfig-plugin.spec
@@ -29,7 +29,6 @@ BuildRoot: %{_tmppath}/%{name}-%{version}-build
 BuildArch: noarch
 Provides:  %{name} = %{version}-%{release}
 Requires:  supportconfig-plugin-resource
-Requires:  supportconfig-plugin-tag
 Requires:  yq
 Requires:  jq
 Requires:  helm

--- a/packaging/suse/trento-supportconfig-plugin/trento-supportconfig-plugin.spec
+++ b/packaging/suse/trento-supportconfig-plugin/trento-supportconfig-plugin.spec
@@ -28,7 +28,7 @@ Source:    %{name}-%{version}.tar.gz
 BuildRoot: %{_tmppath}/%{name}-%{version}-build
 BuildArch: noarch
 Provides:  %{name} = %{version}-%{release}
-Requires:  supportconfig-plugin-resource
+Requires:  supportutils
 Requires:  yq
 Requires:  jq
 Requires:  helm


### PR DESCRIPTION
The "supportconfig-plugin-tag" provides by supportutils is being dropped and not actually required by this package. See bsc#1235145