### PR TITLE
Add a script that extracts aws metadata

### DIFF
--- a/scripts/extract-aws-metadata.sh
+++ b/scripts/extract-aws-metadata.sh
@@ -11,33 +11,32 @@ LOG_FILE="aws_metadata.log"
 # Ensure log file is empty before running
 > "$LOG_FILE"
 
-request_and_log() {
-    local url=$1
+log_request() {
+    local -r request_url=$1
+    local -r response=$2
 
-    echo "[REQUEST] $url" >> "$LOG_FILE"
-
-    response=$(curl -s "$url")
-
+    echo "[REQUEST] $request_url" >> "$LOG_FILE"
     echo -e "[RESPONSE]\n$response" >> "$LOG_FILE"
     echo "----------------------------------------" >> "$LOG_FILE"
+    echo "$response"
+}
 
-    echo $response
+get_metadata() {
+    local -r url=${IMDS_BASE_URL}$1
+
+    log_request "$url" "$(curl -s "$url")"
 }
 
 extract_metadata() {
-    local metadata_path=${1:-"/"}
-    
-    request_url=${IMDS_BASE_URL}$metadata_path
+    local -r metadata_path=${1:-"/"}
 
-    response=$(request_and_log "$request_url")
-
-    for item in $response; do
+    for item in $(get_metadata "$metadata_path"); do
+        local next_path="$metadata_path$item"
+        
         if [[ "$item" == */ ]]; then
-            extract_metadata "$metadata_path$item"
+            extract_metadata "$next_path"
         else
-            local leaf_url=${IMDS_BASE_URL}$metadata_path$item
-
-            request_and_log "$leaf_url" > /dev/null
+            get_metadata "$next_path" > /dev/null
         fi
     done
 }

--- a/scripts/extract-aws-metadata.sh
+++ b/scripts/extract-aws-metadata.sh
@@ -14,11 +14,13 @@ LOG_FILE="aws_metadata.log"
 log_request() {
     local -r request_url=$1
     local -r response=$2
+    local -r is_valid_json=$(echo $response | jq empty > /dev/null 2>&1; echo $?)
+    local -r redacted_response=$([[ $is_valid_json -eq 0 ]] && jq 'walk(if type == "string" and length > 0 then "redacted" else . end)' <<< "$response" || echo "$response")
 
     echo "[REQUEST] $request_url" >> "$LOG_FILE"
-    echo -e "[RESPONSE]\n$response" >> "$LOG_FILE"
+    echo -e "[RESPONSE]\n$redacted_response" >> "$LOG_FILE"
     echo "----------------------------------------" >> "$LOG_FILE"
-    echo "$response"
+    echo "$redacted_response"
 }
 
 get_metadata() {
@@ -41,6 +43,14 @@ extract_metadata() {
     done
 }
 
+check_deps() {
+    if ! which jq >/dev/null 2>&1; then
+        echo "error: jq is required and not installed"
+        exit 1
+    fi
+}
+
+check_deps
 extract_metadata
 
 echo "Metadata requests and responses have been saved to $LOG_FILE"

--- a/scripts/extract-aws-metadata.sh
+++ b/scripts/extract-aws-metadata.sh
@@ -1,0 +1,47 @@
+#!/bin/bash
+
+set -e
+
+# IMDS Base URL
+IMDS_BASE_URL="http://169.254.169.254/latest/meta-data"
+
+# Log file where requests and responses will be stored
+LOG_FILE="aws_metadata.log"
+
+# Ensure log file is empty before running
+> "$LOG_FILE"
+
+request_and_log() {
+    local url=$1
+
+    echo "[REQUEST] $url" >> "$LOG_FILE"
+
+    response=$(curl -s "$url")
+
+    echo -e "[RESPONSE]\n$response" >> "$LOG_FILE"
+    echo "----------------------------------------" >> "$LOG_FILE"
+
+    echo $response
+}
+
+extract_metadata() {
+    local metadata_path=${1:-"/"}
+    
+    request_url=${IMDS_BASE_URL}$metadata_path
+
+    response=$(request_and_log "$request_url")
+
+    for item in $response; do
+        if [[ "$item" == */ ]]; then
+            extract_metadata "$metadata_path$item"
+        else
+            local leaf_url=${IMDS_BASE_URL}$metadata_path$item
+
+            request_and_log "$leaf_url" > /dev/null
+        fi
+    done
+}
+
+extract_metadata
+
+echo "Metadata requests and responses have been saved to $LOG_FILE"


### PR DESCRIPTION
Temporary script to debug what is going wrong with aws metadata extraction.

One notable thing is that sensitive information are extracted as well like `AccessKeyId`, `SecretAccessKey` and not sure if others are involved

Not meant to be merged.