### PR TITLE
Fix service names

### DIFF
--- a/packaging/suse/supportutils-plugin-trento/trento
+++ b/packaging/suse/supportutils-plugin-trento/trento
@@ -261,7 +261,7 @@ if rpm -q --quiet trento-agent; then
     for RPM in trento-agent golang-github-prometheus-node_exporter; do
         rpm_verify $OF $RPM
     done
-    for SERVICE in trento-agent.service prometheus-node_exporter.service; do
+    for SERVICE in trento-agent prometheus-node_exporter; do
         log_cmd $OF "systemctl status ${SERVICE}.service"
     done
 


### PR DESCRIPTION
Remove extra `.service` from systemd unit names.
```
#==[ Command ]======================================#
# /bin/systemctl status trento-agent.service.service
Unit trento-agent.service.service could not be found.
```