### PR TITLE
Extract db usage stats

### DIFF
--- a/packaging/suse/supportutils-plugin-trento/trento
+++ b/packaging/suse/supportutils-plugin-trento/trento
@@ -246,6 +246,36 @@ if rpm -q --quiet trento-web; then
             FROM information_schema.table_privileges 
             WHERE grantee = 'wanda_user'\""
 
+    echo "#==[ Database sizes ]===============================#"
+    su - postgres -c "psql -c \"
+            SELECT datname, pg_size_pretty(pg_database_size(datname)) AS size
+            FROM pg_database
+            WHERE datname IN ('trento','trento_event_store','wanda')
+            ORDER BY datname\""
+    echo
+
+    for DB in trento trento_event_store wanda; do
+        echo "#==[ Approximate row counts: $DB ]==================#"
+        su - postgres -c "psql -d $DB -c \"
+            SELECT schemaname, relname, n_live_tup AS approx_rows
+            FROM pg_stat_user_tables
+            ORDER BY n_live_tup DESC, relname\""
+        echo
+    done
+
+    for DB in trento trento_event_store wanda; do
+        echo "#==[ Table sizes: $DB ]=============================#"
+        su - postgres -c "psql -d $DB -c \"
+            SELECT
+                relname AS table_name,
+                pg_size_pretty(pg_total_relation_size(relid)) AS total_size,
+                pg_size_pretty(pg_relation_size(relid)) AS data_size,
+                pg_size_pretty(pg_indexes_size(relid)) AS index_size
+            FROM pg_catalog.pg_stat_user_tables
+            ORDER BY pg_total_relation_size(relid) DESC\""
+        echo
+    done
+
     log_entry $OF section "Rabbitmq Section"
     #TODO detect vhost name from AMQP_URL
     log_cmd $OF "rabbitmqctl list_permissions -p vhost 2>/dev/null"


### PR DESCRIPTION
Add db usage stats to the extracted support data. The retrieved data is quantitative, thus it does not expose any confidential information about the customer.

The rationale is that, by understanding the usage of the database, we can better reasonate about issues.

