### PR TITLE
[TRNT-4358] Add license headers

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: SUSE LLC
+# SPDX-License-Identifier: Apache-2.0
+
 name: Continuous Integration
 
 on:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -50,6 +50,9 @@ jobs:
       - name: Check for lint issues
         run: make lint
 
+      - name: Check license headers
+        uses: apache/skywalking-eyes/header@61275cc80d0798a405cb070f7d3a8aaf7cf2c2c1 # v0.8.0
+
   test:
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: SUSE LLC
+# SPDX-License-Identifier: Apache-2.0
+
 name: Release
 
 on:

--- a/.licenserc.yaml
+++ b/.licenserc.yaml
@@ -16,3 +16,4 @@ header:
     - ".tool-versions"
     - "LICENSE"
     - "VERSION"
+    - "packaging/suse/supportutils-plugin-trento/trento"

--- a/.licenserc.yaml
+++ b/.licenserc.yaml
@@ -1,0 +1,18 @@
+# SPDX-FileCopyrightText: SUSE LLC
+# SPDX-License-Identifier: Apache-2.0
+
+header:
+  comment: on-failure
+  license:
+    spdx-id: Apache-2.0
+    copyright-owner: SUSE LLC
+    software-name: supportutils-plugin-trento
+    content: |
+      SPDX-FileCopyrightText: SUSE LLC
+      SPDX-License-Identifier: Apache-2.0
+  paths-ignore:
+    - "**/*.adoc"
+    - ".github/dependabot.yml"
+    - ".tool-versions"
+    - "LICENSE"
+    - "VERSION"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+<!--
+  ~ SPDX-FileCopyrightText: SUSE LLC
+  ~ SPDX-License-Identifier: Apache-2.0
+-->
+
 # Changelog
 
 ## 3.0.0 - 2025-11-27

--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: SUSE LLC
+# SPDX-License-Identifier: Apache-2.0
+
 .PHONY: test
 test:
 	bats -r ./test

--- a/packaging/suse/supportutils-plugin-trento/supportutils-plugin-trento.spec
+++ b/packaging/suse/supportutils-plugin-trento/supportutils-plugin-trento.spec
@@ -1,7 +1,8 @@
 #
 # spec file for package supportutils-plugin-trento
 #
-# Copyright (c) 2024 SUSE LLC
+# SPDX-FileCopyrightText: SUSE LLC
+# SPDX-License-Identifier: Apache-2.0
 #
 # All modifications and additions to the file contributed by third parties
 # remain the property of their copyright owners, unless otherwise agreed

--- a/packaging/suse/supportutils-plugin-trento/trento
+++ b/packaging/suse/supportutils-plugin-trento/trento
@@ -3,7 +3,8 @@
 # Name:        Supportconfig Plugin for SUSE Trento
 # Description: Gathers important troubleshooting information
 #              about a SUSE Trento SAP console
-# License:     GPLv2
+# License:     SPDX-FileCopyrightText: SUSE LLC
+#              SPDX-License-Identifier: Apache-2.0
 #############################################################
 
 SVER='1.0.0'
@@ -228,22 +229,22 @@ if rpm -q --quiet trento-web; then
     echo "#==[ trento database permissions ]==================#"
     #TODO detect trento-web database name/user from trento-web's DATABASE_URL
     su - postgres -c "psql -d trento -c \"
-            SELECT grantor, grantee, table_schema, table_name, privilege_type 
-            FROM information_schema.table_privileges 
+            SELECT grantor, grantee, table_schema, table_name, privilege_type
+            FROM information_schema.table_privileges
             WHERE grantee = 'trento_user'\""
 
     echo "#==[ trento_event_store database permissions ]======#"
     #TODO detect trento-web database name/user from trento-web's EVENTSTORE_URL
     su - postgres -c "psql -d trento_event_store -c \"
-            SELECT grantor, grantee, table_schema, table_name, privilege_type 
-            FROM information_schema.table_privileges 
+            SELECT grantor, grantee, table_schema, table_name, privilege_type
+            FROM information_schema.table_privileges
             WHERE grantee = 'trento_user'\""
 
     echo "#==[ wanda database permissions ]===================#"
     #TODO detect trento-wanda database name/user from trento-wanda's DATABASE_URL
     su - postgres -c "psql -d wanda -c \"
-            SELECT grantor, grantee, table_schema, table_name, privilege_type 
-            FROM information_schema.table_privileges 
+            SELECT grantor, grantee, table_schema, table_name, privilege_type
+            FROM information_schema.table_privileges
             WHERE grantee = 'wanda_user'\""
 
     echo "#==[ Database sizes ]===============================#"
@@ -285,7 +286,7 @@ if rpm -q --quiet trento-web; then
     for UNIT in trento-web trento-wanda postgresql-server rabbitmq-server prometheus; do
         log_cmd $OF "journalctl -u ${UNIT} | tail -${VAR_OPTION_LINE_COUNT}"
     done
-    
+
     echo "#==[ Collect Scenario Dump ]=========================================#"
     set -a
     source /etc/trento/trento-web

--- a/test/test.bats
+++ b/test/test.bats
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: SUSE LLC
+# SPDX-License-Identifier: Apache-2.0
+
 setup() {
 	# Set the test root as the project root
 	ROOT="$(cd "$(dirname "$BATS_TEST_FILENAME")/.." >/dev/null 2>&1 && pwd)"

--- a/trento-support.sh
+++ b/trento-support.sh
@@ -1,5 +1,9 @@
 #!/bin/bash
 
+# SPDX-FileCopyrightText: SUSE LLC
+# SPDX-License-Identifier: Apache-2.0
+
+
 set -e
 
 readonly ARGS=("$@")

--- a/trento-support.sh
+++ b/trento-support.sh
@@ -3,7 +3,6 @@
 # SPDX-FileCopyrightText: SUSE LLC
 # SPDX-License-Identifier: Apache-2.0
 
-
 set -e
 
 readonly ARGS=("$@")


### PR DESCRIPTION
# Description

In an attempt to follow the REUSE Specification (supported by the Linux Foundation) for managing licence information, this PR adds the recommended `SPDX-FileCopyrightText` and `SPDX-License-Identifier` headers.

Besides, a new linter is added for the CI to check the license headers. 

Related # TRNT-4358

## How was this tested?

License linter.